### PR TITLE
Update example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ jobs:
         run: echo Deploy
       - name: End Standard Change
         uses: byu-oit/github-action-end-standard-change@v1
-        if: ${{ always() && steps.start-standard-change.outcome == 'success' }} # Run if RFC started, even if the deploy failed
+        if: always() && steps.start-standard-change.outcome == 'success' # Run if RFC started, even if the deploy failed
         with:
           client-key: ${{ secrets.STANDARD_CHANGE_SANDBOX_CLIENT_KEY }}
           client-secret: ${{ secrets.STANDARD_CHANGE_SANDBOX_CLIENT_SECRET }}
           change-sys-id: ${{ steps.start-standard-change.outputs.change-sys-id }}
           work-start: ${{ steps.start-standard-change.outputs.work-start }}
-          success: ${{ steps.deploy.outcome == 'success' }}
+          success: ${{ job.status == 'success' }}
 ```
 
 </p>
@@ -62,6 +62,8 @@ jobs:
 <details>
 <summary>In a workflow where the deploy phase is a job, do this...</summary>
 <p>
+
+Have a job with an `id` of `deploy` (or change this example accordingly), then
 
 ```yaml
 on: push
@@ -97,7 +99,7 @@ jobs:
   end-standard-change:
     name: End Standard Change
     needs: [deploy, start-standard-change] # We need to wait on outcome of deploy, and we list start-standard-change so that we can grab its outputs
-    if: ${{ always() && needs.start-standard-change.result == 'success' }} # Run if RFC started, even if the deploy failed
+    if: always() && needs.start-standard-change.result == 'success' # Run if RFC started, even if the deploy failed
     runs-on: ubuntu-latest
     steps:
       - uses: byu-oit/github-action-end-standard-change@v1


### PR DESCRIPTION
We've now had two people get burned by the way `${{ steps.deploy.outcome == 'success' }}` silently evaluates to `false` when there's no step with an `id` of `deploy`.

The thinking is that 

- `success: ${{ success() }}` doesn't work as you might expect in the `continue-on-error` case, but otherwise works great
- `success: ${{ steps.deploy.outcome == 'success' }}` works great but silently fails if no step with an `id` of `deploy` exists (which apparently happens often when copying/pasting)
- `success: ${{ job.status == 'success' }}` probably works great when running `if: always() && steps.start-standard-change.outcome == 'success'`

Refs: https://byu-oit.slack.com/archives/CQ2BE663T/p1592410344429600
Refs: https://byu-oit.slack.com/archives/CQ2BE663T/p1595350304226300